### PR TITLE
feat: cap scraped content length before sending to ollama

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     database_url: str = "sqlite:///./distill.db"
     ollama_base_url: str = "http://localhost:11434"
     ollama_model: str = "llama3.2"
+    max_content_chars: int = 50_000
 
 
 settings = Settings()

--- a/app/routes/summarize.py
+++ b/app/routes/summarize.py
@@ -19,6 +19,7 @@ async def create_summary(request: SummarizeRequest, db: Session = Depends(get_db
     """
     log.info("summary requested", url=str(request.url))
     text = await scraper.fetch_text(str(request.url))
+    text = text[: settings.max_content_chars]
     summary = await ollama.summarize(text=text, length=request.length)
     record = summary_repo.create(
         db,
@@ -96,6 +97,7 @@ async def retry_summary(summary_id: int, db: Session = Depends(get_db)):
     if record is None:
         raise HTTPException(status_code=404, detail="Not found")
     text = await scraper.fetch_text(record.url)
+    text = text[: settings.max_content_chars]
     summary = await ollama.summarize(text=text)
     updated_record = summary_repo.update(
         db,

--- a/tests/routes/test_summarize.py
+++ b/tests/routes/test_summarize.py
@@ -307,3 +307,36 @@ def test_retry_summary_success(client, db_session):
     assert response.status_code == 200
     assert response.json()["summary"] == "the summary"
     assert response.json()["url"] == "https://example.com"
+
+
+def test_post_summarize_truncates_long_content(client):
+    long_text = "a" * 100_000
+
+    with patch(
+        "app.services.scraper.fetch_text", new=AsyncMock(return_value=long_text)
+    ):
+        with patch(
+            "app.services.ollama.summarize", new=AsyncMock(return_value="the summary")
+        ) as mock_ollama:
+            client.post("/summarize", json={"url": "https://example.com"})
+
+    actual_text = mock_ollama.call_args.kwargs["text"]
+    assert len(actual_text) == 50_000
+
+
+def test_retry_summarize_truncates_long_content(client, db_session):
+    record = summary_repo.create(
+        db_session, url="https://example.com", summary="A summary", model="llama3.2"
+    )
+    long_text = "a" * 100_000
+
+    with patch(
+        "app.services.scraper.fetch_text", new=AsyncMock(return_value=long_text)
+    ):
+        with patch(
+            "app.services.ollama.summarize", new=AsyncMock(return_value="the summary")
+        ) as mock_ollama:
+            client.post(f"/summarize/history/{record.id}/retry")
+
+    actual_text = mock_ollama.call_args.kwargs["text"]
+    assert len(actual_text) == 50_000


### PR DESCRIPTION
Close https://github.com/franverona/distill/issues/47
